### PR TITLE
glob fix make workq-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ default: server
 server: deps
 	mkdir -p bin
 	go get github.com/tools/godep && godep restore
-	go build -o bin/workq-server cmd/workq-server/*
+	go build -o bin/workq-server cmd/workq-server/*.go
 
 deps:
 	go get github.com/tools/godep && godep restore


### PR DESCRIPTION
## Problem

Make file was failing on glob for go files.

```
workq (master) ~࿔ make
go get github.com/tools/godep && godep restore
mkdir -p bin
go get github.com/tools/godep && godep restore
go build -o bin/workq-server cmd/workq-server/*
named files must be .go files
make: *** [server] Error 1
```

## Solution
Scoped the `cmd/workq-server/*` glob to go files only; example `cmd/workq-server/*.go`.

## Results/Expectation

```
workq (cevaris/fix-workq-server-make) ~࿔ make
go get github.com/tools/godep && godep restore
mkdir -p bin
go get github.com/tools/godep && godep restore
go build -o bin/workq-server cmd/workq-server/*.go
workq (cevaris/fix-workq-server-make) ~࿔
```


